### PR TITLE
Update trivy.yml

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -42,7 +42,10 @@ jobs:
           docker build -t docker.io/${{ steps.lower_repo.outputs.repo_name }}:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@7b7aa264d3dc58691451798b4d117d53d21edfe
+        # Changed the reference to the main branch to work around the
+        # "unable to resolve version" error. This is a more direct way
+        # to get the latest code.
+        uses: aquasecurity/trivy-action@main
         with:
           image-ref: 'docker.io/${{ steps.lower_repo.outputs.repo_name }}:${{ github.sha }}'
           format: 'template'


### PR DESCRIPTION
I've updated the uses line to @main instead of @v0.32.0. This should force the runner to pull the latest version directly from the main branch. Let me know if this solves the problem!

## Summary
- What changed? Why?

## Linked Docs
- PRD/Design sections updated: [ ] Yes  [ ] N/A

## Tests
- Unit: [ ] added/updated
- E2E:  [ ] added/updated

## Checks
- [ ] Lints/types pass
- [ ] No secrets introduced

